### PR TITLE
Add `untrust` ipc method

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -38,7 +38,8 @@ const methods = [
   { id: 35, name: 'encryptionKey', stream: true },
   { id: 36, name: 'trusted' },
   { id: 37, name: 'touch', stream: true },
-  { id: 38, name: '_ping' }
+  { id: 38, name: '_ping' },
+  { id: 39, name: 'untrust' },
 ]
 
 module.exports = methods

--- a/methods.js
+++ b/methods.js
@@ -39,7 +39,7 @@ const methods = [
   { id: 36, name: 'trusted' },
   { id: 37, name: 'touch', stream: true },
   { id: 38, name: '_ping' },
-  { id: 39, name: 'untrust' },
+  { id: 39, name: 'untrust' }
 ]
 
 module.exports = methods


### PR DESCRIPTION
# Context
- We would like doctor to test TrustDialog for new key
- To do that, we need to untrust the key first
- Then click/run on the key again
- The TrustDialog should open

# Related PRs
- Add `untrust` method to `pear-ipc`: https://github.com/holepunchto/pear-ipc/pull/16
- Add `untrust` method to `pear sidecar`: https://github.com/holepunchto/pear/pull/356
- Add test section to `pear-doctor`: TODO
