### PR TITLE
removed uneeded rpc destroy on client close

### DIFF
--- a/client.js
+++ b/client.js
@@ -188,7 +188,6 @@ class PearIPCClient extends ReadyResource {
       this._rawStream = null
       this._stream = null
     }
-    this._rpc.destroy()
   }
 }
 


### PR DESCRIPTION
This PR removes uneeded rpc destroy call on client close as already done in server close here https://github.com/holepunchto/pear-ipc/commit/7992dcc21e706d9cb9bc3bb1c55e32e2dfeae4f6#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL233